### PR TITLE
DesignSystem Color 확장 추가

### DIFF
--- a/DesignSystem/Resources/Assets.xcassets/Colors/Contents.json
+++ b/DesignSystem/Resources/Assets.xcassets/Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DesignSystem/Resources/Assets.xcassets/Colors/primary800.colorset/Contents.json
+++ b/DesignSystem/Resources/Assets.xcassets/Colors/primary800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x61",
+          "green" : "0x00",
+          "red" : "0x14"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DesignSystem/Resources/Assets.xcassets/Colors/primary900.colorset/Contents.json
+++ b/DesignSystem/Resources/Assets.xcassets/Colors/primary900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x00",
+          "red" : "0x0A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DesignSystem/Sources/Color+Extension.swift
+++ b/DesignSystem/Sources/Color+Extension.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SwiftUI
+
+public extension Color {
+    static var primary800: Color { asset(#function) }
+    static var primary900: Color { asset(#function) }
+
+    private static func asset(_ name: String) -> Color {
+        Color(name, bundle: .module)
+    }
+}

--- a/DesignSystem/Sources/Empty.swift
+++ b/DesignSystem/Sources/Empty.swift
@@ -1,3 +1,0 @@
-import Foundation
-
-// Add your DesignSystem code here


### PR DESCRIPTION
## 개요
DesignSystem에 primary800, primary900 컬러를 추가하고 Color extension을 개선했습니다.

## 주요 변경사항
- Empty.swift → Color+Extension.swift로 파일명 변경
- primary800 (#140061), primary900 (#0A002E) Color Asset 추가
- `asset()` 헬퍼 함수를 통한 코드 중복 제거
- `#function`을 활용하여 간결한 Color 확장 패턴 적용

## 사용 방법
```swift
import DesignSystem

Text("Hello")
    .foregroundColor(.primary800)
```

## 테스트
- [ ] primary800, primary900 컬러가 정상적으로 표시되는지 확인
- [ ] 다른 모듈에서 import하여 사용 가능한지 확인